### PR TITLE
Make the library less dependent of the colors header

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,8 @@ $(LIB_HEADER_DEPLOY_FILEPATH): $(BINLIBDIR)
 	@$(FIND) src/data -path "*.h" -type f -exec tools/printSingleHeaderContent.sh {} \; | grep -v '#include "' >> $@
 	@$(MSG) "\n/** CORE FUNCTIONALITIES: */\n" >> $@
 	@$(FIND) src/core -path "*.h" -type f -exec tools/printSingleHeaderContent.sh {} \; | grep -v '#include "' >> $@
+	@$(MSG) "\n/** UTILITIES: */\n" >> $@
+	@$(FIND) tools/printSingleHeaderContent.sh ./src/util/messages.h | grep -v '#include "' >> $@
 	@$(MSG) "\n#endif /* POKEM_H */" >> $@
 
 # Static library

--- a/src/core/Convert/Convert.c
+++ b/src/core/Convert/Convert.c
@@ -7,6 +7,7 @@
 #include "../../data/md1global/md1global.h"
 #include "../../data/md1database/md1database.h"
 #include "../../util/messages.h"
+#include "../../util/colors.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/src/core/Decode/DecodeSos/DecodeSos.c
+++ b/src/core/Decode/DecodeSos/DecodeSos.c
@@ -3,6 +3,7 @@
 #include "../../UtilCore/UtilCore.h"
 #include "../../../data/md1database/md1database.h"
 #include "../../../util/messages.h"
+#include "../../../util/colors.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/src/core/Decode/DecodeWonderMail/DecodeWonderMail.c
+++ b/src/core/Decode/DecodeWonderMail/DecodeWonderMail.c
@@ -4,6 +4,7 @@
 #include "../../../data/md1database/md1database.h"
 #include "../../../data/md1global/md1global.h"
 #include "../../../util/messages.h"
+#include "../../../util/colors.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/src/util/messages.c
+++ b/src/util/messages.c
@@ -1,5 +1,19 @@
 #include "messages.h"
 
+#if !defined(NO_USE_COLORS)
+    #define RESETCOLORS "\x1B[0m"   /* all attributes off */
+    #define DARKGREEN   "\x1B[32m"
+    #define LIGHTRED    "\x1B[31;1m"
+    #define LIGHTGREEN  "\x1B[32;1m"
+    #define LIGHTYELLOW "\x1B[33;1m"
+#else
+    #define RESETCOLORS ""
+    #define DARKGREEN   ""
+    #define LIGHTRED    ""
+    #define LIGHTGREEN  ""
+    #define LIGHTYELLOW ""
+#endif
+
 int printMessages = 1;
 
 int printMessage(FILE *stream, enum MessageType messageType, const char* message, ...)
@@ -8,7 +22,7 @@ int printMessage(FILE *stream, enum MessageType messageType, const char* message
     int charactersReturned = 0;
     const char* messageTypesStr[] = { "DEBUG", "INFO", "WARNING", "ERROR", "FATAL ERROR" };
 #ifndef NO_USE_COLORS
-    const char* messageColorsByTypes[] = { DGREEN, LGREEN, LYELLOW, LRED, LRED };
+    const char* messageColorsByTypes[] = { DARKGREEN, LIGHTGREEN, LIGHTYELLOW, LIGHTRED, LIGHTRED };
 #else
     const char* messageColorsByTypes[] = { {0}, {0}, {0}, {0}, {0} };
 #endif
@@ -17,7 +31,7 @@ int printMessage(FILE *stream, enum MessageType messageType, const char* message
         return 0;
     }
 
-    charactersReturned += fprintf(stream, "%s%s: " RESET, messageColorsByTypes[messageType], messageTypesStr[messageType]);
+    charactersReturned += fprintf(stream, "%s%s: " RESETCOLORS, messageColorsByTypes[messageType], messageTypesStr[messageType]);
     va_start(argList, message);
     charactersReturned += vfprintf(stream, message, argList);
     va_end(argList);

--- a/src/util/messages.h
+++ b/src/util/messages.h
@@ -3,7 +3,6 @@
 
 #include <stdio.h>
 #include <stdarg.h>
-#include "colors.h"
 
 /* Message type */
 enum MessageType { DebugMessage, InfoMessage, WarningMessage, ErrorMessage, FatalMessage };


### PR DESCRIPTION
Make the library less dependent of the colors header by implementing the colors used in messages.c. Also deploy `messages.h` in `pokem.h`